### PR TITLE
chore: Add docker compose for postgres and npm start commands

### DIFF
--- a/src/server/.config/dotnet-tools.json
+++ b/src/server/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-ef": {
+      "version": "9.0.4",
+      "commands": [
+        "dotnet-ef"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/src/server/Infra/docker-compose.yml
+++ b/src/server/Infra/docker-compose.yml
@@ -1,0 +1,25 @@
+﻿services:
+  postgres:
+    image: postgres:latest
+    container_name: postgres-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: l0wpressure
+      POSTGRES_DB: defaultdb  # Required by image, but we'll create our own databases in the init-db script
+    ports:
+      - "5432:5432"
+    volumes:
+      - lpz:/var/lib/postgresql/data
+      - ./init-db:/docker-entrypoint-initdb.d
+    healthcheck:
+      test: [
+        "CMD-SHELL",
+        "pg_isready -U postgres -d postgres || exit 1"
+      ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes: #stores database locally so it persists between restarts. Can be removed with 'docker-compose down -v' command
+  lpz:

--- a/src/server/Infra/init-db/create-databases.sql
+++ b/src/server/Infra/init-db/create-databases.sql
@@ -1,0 +1,2 @@
+﻿CREATE DATABASE "lpz-data";
+CREATE DATABASE "lpz-identity";

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -1,0 +1,14 @@
+﻿{
+  "name": "dotnet-dev-environment",
+  "version": "1.0.0",
+  "description": "Development environment for .NET and PostgreSQL",
+  "scripts": {
+    "dev": "npm run start-db && npm run migrate-api && npm run migrate-auth && npm run start-api",
+    "start-db": "docker-compose -f ./Infra/docker-compose.yml up -d",      
+    "start-api": "dotnet watch run --project LowPressureZone.Api",  
+    "stop": "docker-compose -f ./Infra/docker-compose.yml down",              
+    "clean": "docker-compose -f ./Infra/docker-compose.yml down -v",           
+    "migrate-api": "dotnet tool restore && dotnet tool run dotnet-ef database update --context DataContext --project LowPressureZone.Domain --startup-project LowPressureZone.Api",
+    "migrate-auth": "dotnet tool run dotnet-ef database update --context IdentityContext --project LowPressureZone.Identity --startup-project LowPressureZone.Api"
+  }
+}


### PR DESCRIPTION
Test:

- Ensure [docker desktop](https://www.docker.com/get-started/) is installed and running
- run `npm run start` in the `\low-pressure-zone\src\server` directory
  - if pgsql is already running locally on port 5432 you'll prob run into issues
  
- [ ] Docker Container for Postgres should start
- [ ] Migrations for API should run
- [ ] Migrations for Identity should run
- [ ] `dotnet watch run` should start API