### PR TITLE
#180 Fix width of home element, remove permanent scroll bar

### DIFF
--- a/src/client/src/assets/main.scss
+++ b/src/client/src/assets/main.scss
@@ -26,7 +26,7 @@ body {
   background-attachment: fixed;
   font-family: 'Nunito Sans', 'Helvetica Neue', sans-serif;
   text-rendering: optimizeLegibility;
-  overflow-y: scroll;
+  overflow-y: auto;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/src/client/src/assets/styles/_variables.scss
+++ b/src/client/src/assets/styles/_variables.scss
@@ -11,10 +11,10 @@ $space-l: 20px;
 
 $header-height: 82px;
 $footer-height: 70px;
-$view-min-height: calc(100dvh - #{$header-height} - #{$footer-height});
+$view-min-height: calc(100dvh - #{$header-height} - #{$footer-height} - 1px);
 
 $mobile-transition-width: 760px;
-$mobile-element-width: calc(100vw - 2 * $space-m);
+$mobile-element-width: calc(min(100vw, #{$mobile-transition-width}) - 2 * $space-m);
 
 $grid-action-width: 50px;
 

--- a/src/client/src/components/layout/site/SiteFooter.vue
+++ b/src/client/src/components/layout/site/SiteFooter.vue
@@ -18,6 +18,5 @@ import PlayButton from '../../controls/PlayButton.vue'
 
 .site-footer {
   position: sticky;
-  bottom: 0;
 }
 </style>

--- a/src/client/src/components/views/home/HomeView.vue
+++ b/src/client/src/components/views/home/HomeView.vue
@@ -13,5 +13,8 @@ import UpcomingSchedules from './UpcomingSchedules.vue'
 
 .home-view {
   margin: 0 variables.$space-m;
+  @include variables.desktop {
+    max-width: calc(#{variables.$mobile-element-width} + 200px);
+  }
 }
 </style>


### PR DESCRIPTION
Closes #180 

Testing: Create a schedule with a long description. Navigate to home page.

Grow/shrink screen width, it should be reactive the whole way until a point. The original reqs were 45% of screen width max, but that didn't provide a reactive experience.