### PR TITLE
Add same site cookie handling policy for chromium local dev

### DIFF
--- a/src/server/LowPressureZone.Api/Program.cs
+++ b/src/server/LowPressureZone.Api/Program.cs
@@ -17,7 +17,7 @@ builder.Services.Configure<JsonOptions>(options =>
 {
     options.JsonSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
 });
-builder.Services.ConfigureIdentity();
+builder.Services.ConfigureIdentity(builder.Environment);
 builder.Services.ConfigureWebApi();
 builder.Services.AddApiServices();
 


### PR DESCRIPTION
https://github.com/AzureAD/microsoft-identity-web/wiki/samesite-cookies

Identity cookies were not being sent in headers in Chromium browsers due to default `SameSite=Lax`.
Update to `SameSite=None` for local dev

Test:

- Login locally with Cookies cleared in Chrome/Edge
- [ ] Ensure 2FA login token verify is successful and dashboard is displayed