### PR TITLE
Add optional remember device on 2FA verify

### DIFF
--- a/src/client/src/api/resources/authApi.ts
+++ b/src/client/src/api/resources/authApi.ts
@@ -7,7 +7,7 @@ export default {
   postLogin: (request: LoginRequest) =>
     sendPost<LoginRequest, LoginResponse>(`${route}/login`, request),
   getLogout: () => sendGet<never>(`${route}/logout`),
-  postTwoFactor: (code: string) => sendPost(`${route}/twoFactor`, { code: code }),
+  postTwoFactor: (request: TwoFactorRequest) => sendPost(`${route}/twoFactor`, request),
   getResetPassword: (email: string) => sendGet(`${route}/resetPassword`, { email: email }),
   postResetPassword: (request: ResetPasswordRequest) => sendPost(`${route}/resetPassword`, request),
   postRegister: (request: RegisterRequest) => sendPost(`${route}/register`, request),
@@ -28,6 +28,11 @@ export interface LoginRequest {
 
 export interface LoginResponse {
   requiresTwoFactor: boolean
+}
+
+export interface TwoFactorRequest {
+  code: string
+  rememberClient: boolean
 }
 
 export interface RegisterRequest {

--- a/src/client/src/components/views/user/TwoFactorView.vue
+++ b/src/client/src/components/views/user/TwoFactorView.vue
@@ -21,6 +21,17 @@
           :autofocus="true"
           :invalid="errorMessage !== ''" />
       </IftaFormField>
+      <FormField input-id="rememberBrowserInput">
+        <div style="display: flex; flex-direction: column; align-items: center; width: 100%">
+          <div class="checkbox-area__item">
+            <Checkbox
+              id="rememberBrowserInput"
+              v-model="formState.rememberClient"
+              binary />
+            <span>Remember Browser</span>
+          </div>
+        </div>
+      </FormField>
       <template #actions>
         <Button
           :disabled="isSubmitting"
@@ -37,7 +48,7 @@ import { KeyName } from '@/constants/keys'
 import { Routes } from '@/router/routes'
 import { useAuthStore } from '@/stores/authStore'
 import { onKeyDown } from '@vueuse/core'
-import { Button, InputText, Message } from 'primevue'
+import { Button, Checkbox, InputText, Message } from 'primevue'
 import { reactive, ref } from 'vue'
 import authApi from '@/api/resources/authApi.ts'
 import FormArea from '@/components/form/FormArea.vue'
@@ -49,7 +60,8 @@ import SinglePanelViewWrapper from '@/components/layout/SinglePanelViewWrapper.v
 const router = useRouter()
 
 const formState = reactive({
-  code: ''
+  code: '',
+  rememberClient: false
 })
 
 onKeyDown(KeyName.Enter, () => handleVerify())
@@ -68,7 +80,7 @@ const props = withDefaults(
 
 const handleVerify = async () => {
   isSubmitting.value = true
-  const response = await authApi.postTwoFactor(formState.code)
+  const response = await authApi.postTwoFactor(formState)
   if (!response.isSuccess()) {
     errorMessage.value = 'Invalid code'
     isSubmitting.value = false

--- a/src/server/LowPressureZone.Api/Endpoints/Users/TwoFactor/PostTwoFactor.cs
+++ b/src/server/LowPressureZone.Api/Endpoints/Users/TwoFactor/PostTwoFactor.cs
@@ -19,7 +19,7 @@ public class PostTwoFactor(SignInManager<AppUser> signInManager) : Endpoint<TwoF
 
     public override async Task HandleAsync(TwoFactorRequest req, CancellationToken ct)
     {
-        var result = await signInManager.TwoFactorSignInAsync(TokenProviders.Email, req.Code, true, false);
+        var result = await signInManager.TwoFactorSignInAsync(TokenProviders.Email, req.Code, true, req.RememberClient);
         if (result.Succeeded)
         {
             await SendNoContentAsync(ct);

--- a/src/server/LowPressureZone.Api/Endpoints/Users/TwoFactor/TwoFactorRequest.cs
+++ b/src/server/LowPressureZone.Api/Endpoints/Users/TwoFactor/TwoFactorRequest.cs
@@ -3,4 +3,5 @@
 public class TwoFactorRequest
 {
     public required string Code { get; set; }
+    public bool RememberClient { get; set; }
 }

--- a/src/server/LowPressureZone.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/src/server/LowPressureZone.Api/Extensions/ServiceCollectionExtensions.cs
@@ -66,6 +66,8 @@ public static class ServiceCollectionExtensions
         {
             // Also configure Auth cookies separately, so SameSite works cross domain locally in Chromium
             services.Configure(IdentityConstants.TwoFactorUserIdScheme, ConfigureDevCookieOptions);
+            services.Configure(IdentityConstants.TwoFactorRememberMeScheme, ConfigureDevCookieOptions);
+            services.Configure(IdentityConstants.ExternalScheme, ConfigureDevCookieOptions);
             services.ConfigureApplicationCookie(ConfigureDevCookieOptions);
         }
         else


### PR DESCRIPTION
POST
https://localhost:5002/api/users/twofactor?RememberClient=True&Code={code}

![Screenshot 2025-04-29 223712](https://github.com/user-attachments/assets/e43fda61-a69f-4d75-8010-84b45a1d5506)
As long as the `Identity.TwoFactorRememberMe` Cookie is present 2FA is not required.

`signInResult.RequiresTwoFactor` is returned `false` in `PostLogin` with the Cookie present.