### PR TITLE
Fix subtitle not saving on timeslot form

### DIFF
--- a/src/server/LowPressureZone.Api/Converters/TimeslotRequestToAzuraCastPlaylistConverter.cs
+++ b/src/server/LowPressureZone.Api/Converters/TimeslotRequestToAzuraCastPlaylistConverter.cs
@@ -25,9 +25,9 @@ public sealed class TimeslotRequestToAzuraCastPlaylistConverter(DataContext data
                                                            && schedule.EndsAt >= source.EndsAt)
                                         .FirstAsync(ct);
 
-        var title = string.IsNullOrWhiteSpace(source.Name)
+        var title = string.IsNullOrWhiteSpace(source.Subtitle)
                         ? schedule.StartsAt.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)
-                        : source.Name;
+                        : source.Subtitle;
 
         var playlistEnd = source.EndsAt.AddMinutes(5);
 

--- a/src/server/LowPressureZone.Api/Endpoints/Timeslots/TimeslotMapper.cs
+++ b/src/server/LowPressureZone.Api/Endpoints/Timeslots/TimeslotMapper.cs
@@ -14,7 +14,7 @@ public sealed class TimeslotMapper(
     public Timeslot ToEntity(TimeslotRequest req)
         => new()
         {
-            Subtitle = req.Name?.Trim(),
+            Subtitle = req.Subtitle?.Trim(),
             StartsAt = req.StartsAt.ToUniversalTime(),
             EndsAt = req.EndsAt.ToUniversalTime(),
             Type = req.PerformanceType.Trim(),
@@ -25,7 +25,7 @@ public sealed class TimeslotMapper(
 
     public void UpdateEntity(TimeslotRequest req, Timeslot timeslot)
     {
-        timeslot.Subtitle = req.Name?.Trim();
+        timeslot.Subtitle = req.Subtitle?.Trim();
         timeslot.StartsAt = req.StartsAt.ToUniversalTime();
         timeslot.EndsAt = req.EndsAt.ToUniversalTime();
         timeslot.Type = req.PerformanceType.Trim();

--- a/src/server/LowPressureZone.Api/Endpoints/Timeslots/TimeslotRequest.cs
+++ b/src/server/LowPressureZone.Api/Endpoints/Timeslots/TimeslotRequest.cs
@@ -7,7 +7,7 @@ public sealed class TimeslotRequest : IDateTimeRange
     public required Guid ScheduleId { get; set; }
     public required Guid PerformerId { get; set; }
     public required string PerformanceType { get; set; }
-    public string? Name { get; set; }
+    public string? Subtitle { get; set; }
     public bool? ReplaceMedia { get; set; }
     public IFormFile? File { get; set; }
     public required DateTimeOffset StartsAt { get; set; }

--- a/src/server/LowPressureZone.Api/Endpoints/Timeslots/TimeslotRequestValidator.cs
+++ b/src/server/LowPressureZone.Api/Endpoints/Timeslots/TimeslotRequestValidator.cs
@@ -27,8 +27,8 @@ public sealed class TimeslotRequestValidator : Validator<TimeslotRequest>
         RuleFor(request => request.StartsAt).GreaterThan(DateTime.UtcNow).WithMessage(Errors.TimeInPast);
         RuleFor(request => request.EndsAt).GreaterThan(request => request.StartsAt);
 
-        RuleFor(request => request.Name).MaximumLength(64)
-                                        .WithMessage(Errors.MaxLength(64));
+        RuleFor(request => request.Subtitle).MaximumLength(64)
+                                            .WithMessage(Errors.MaxLength(64));
 
         RuleFor(t => t).CustomAsync(async (request, context, ct) =>
         {

--- a/src/server/LowPressureZone.Api/Services/Files/PrerecordedMixFileProcessor.cs
+++ b/src/server/LowPressureZone.Api/Services/Files/PrerecordedMixFileProcessor.cs
@@ -228,9 +228,9 @@ public sealed class PrerecordedMixFileProcessor(
                                              .Where(performer => performer.Id == request.PerformerId)
                                              .Select(performer => performer.Name)
                                              .FirstAsync(ct);
-        var title = string.IsNullOrWhiteSpace(request.Name)
+        var title = string.IsNullOrWhiteSpace(request.Subtitle)
                         ? scheduleStart.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)
-                        : request.Name;
+                        : request.Subtitle;
         return new SimpleAudioMetadata(title,
                                        performerName);
     }


### PR DESCRIPTION
Renamed Name property to Subtitle on TimeslotRequest class. This made it aligned with the domain model and the client API model.

Closes #423 